### PR TITLE
fix: Rename poliboard microfrontend base path to `/poliboard-mf/` to …

### DIFF
--- a/client/src/pages/PoliBoardPage.jsx
+++ b/client/src/pages/PoliBoardPage.jsx
@@ -14,7 +14,6 @@ import {
 
 const { Title, Paragraph, Text } = Typography
 import { useNavigate } from 'react-router-dom'
-import { CoffeeOutlined } from '@ant-design/icons'
 
 const PoliBoardApp = React.lazy(() => import('poliboard/Board'))
 

--- a/deploy/nginx-reverse-proxy.example.conf
+++ b/deploy/nginx-reverse-proxy.example.conf
@@ -14,7 +14,7 @@ location /lunch-vote-mf/ {
     proxy_set_header X-Forwarded-Proto $scheme;
 }
 
-location /poliboard/ {
+location /poliboard-mf/ {
     proxy_pass http://127.0.0.1:5807/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/poliboard/README.md
+++ b/poliboard/README.md
@@ -180,14 +180,14 @@ Examples:
 - As a subdomain:
   - `https://mf.your-domain.com/assets/remoteEntry.js`
 - As a sub‑path:
-  - `https://your-domain.com/poliboard/assets/remoteEntry.js`
+  - `https://your-domain.com/poliboard-mf/assets/remoteEntry.js`
 
-If you host under a sub‑path (e.g. `/poliboard/`), set `base` in `vite.config.ts`:
+If you host under a sub‑path (e.g. `/poliboard-mf/`), set `base` in `vite.config.ts`:
 
 ```ts
 // poliboard/vite.config.ts
 export default defineConfig({
-  base: '/poliboard/',
+  base: '/poliboard-mf/',
   // existing config...
 })
 ```
@@ -209,7 +209,7 @@ or, if using a sub‑path:
 
 ```js
 remotes: {
-  poliboard: 'https://your-domain.com/poliboard/assets/remoteEntry.js',
+  poliboard: 'https://your-domain.com/poliboard-mf/assets/remoteEntry.js',
 },
 ```
 
@@ -318,5 +318,6 @@ Then rebuild & redeploy the host container/image.
 
 > **Notes:**
 > - The host cannot use Docker‑internal DNS like `http://poliboard/...` because the browser cannot resolve that.
-> - In a real production setup, put a reverse proxy (Nginx/Traefik) in front and expose under the same domain, e.g. `https://your-domain.com/poliboard/assets/remoteEntry.js`.  
->   If you do that, also set `base: '/poliboard/'` in `vite.config.ts` and rebuild.
+> - In a real production setup, put a reverse proxy (Nginx/Traefik) in front and expose under the same domain, e.g. `https://your-domain.com/poliboard-mf/assets/remoteEntry.js`.  
+>   If you do that, also set `base: '/poliboard-mf/'` in `vite.config.ts` and rebuild.
+> - **CRITICAL:** Do NOT use `/poliboard/` as the proxy path, because it will collide with the React Router page path (`/poliboard`). Use `/poliboard-mf/` (similar to `/lunch-vote-mf/`) to avoid Module Federation chunk loading errors (text/html) when users reload the page!


### PR DESCRIPTION
…prevent routing conflicts and remove an unused icon import.